### PR TITLE
Add fix for random salt generator

### DIFF
--- a/Salt.php
+++ b/Salt.php
@@ -59,6 +59,9 @@ class Salt {
 
 	protected static $instance;
 
+	/**
+	 * @return Salt
+	 */
 	public static function instance() {
 		if (!isset(static::$instance)) {
 			static::$instance = new Salt();
@@ -73,21 +76,19 @@ class Salt {
 	 * @return string
 	 */
 	public static function randombytes($length = 32) {
-		$raw = '';
+		$raw = false;
 		if (is_readable('/dev/urandom')) {
-			$fp = true;
-			if ($fp === true) {
-				$fp = @fopen('/dev/urandom', 'rb');
-			}
-			if ($fp !== true && $fp !== false) {
+			$fp = @fopen('/dev/urandom', 'rb');
+			if ($fp !== false) {
 				$raw = fread($fp, $length);
+				fclose($fp);
 			}
 		} else if (function_exists('mcrypt_create_iv')) {
 			$raw = mcrypt_create_iv($length, MCRYPT_DEV_URANDOM);
 		} else if (function_exists('openssl_random_pseudo_bytes')) {
 			$raw = openssl_random_pseudo_bytes($length);
 		}
-		if (!$raw || strlen($raw) !== $length) {
+		if ($raw === false || strlen($raw) !== $length) {
 			throw new SaltException('Unable to generate randombytes');
 		}
 		return $raw;


### PR DESCRIPTION
by Threema, released with v1.1.7 of their [PHP Gateway SDK](https://gateway.threema.ch/en/developer/sdk-php) ([GitHub mirror](https://github.com/rugk/threema-msgapi-sdk-php)) under the MIT license.

Description: "Fix SALT random generator (failed if only one bytes was requested and this happened to be '0')"
